### PR TITLE
docs: align remote humidity source (issue #19)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -194,8 +194,7 @@ a5b6 10 06 05 07 00 00 00 00 14
 
 > **Note:** This packet does NOT contain Remote sensor data. Remote temperature
 > and humidity are in the **SCHEDULE packet** (type 0x02, bytes 11 and 13),
-> returned by FULL_DATA_Q (param 0x06). Remote humidity is also in
-> DEVICE_STATE byte 4.
+> returned by FULL_DATA_Q (param 0x06).
 
 ### 4.4 Remote Sensor Data (in Schedule packet, type 0x02)
 

--- a/src/visionair_ble/client.py
+++ b/src/visionair_ble/client.py
@@ -194,17 +194,16 @@ class VisionAirClient:
         """Get device status with fresh sensor readings.
 
         Sends three separate requests to collect all sensor data:
-        - DEVICE_STATE (0x01): device config, airflow mode, remote humidity
+        - DEVICE_STATE (0x01): device config and airflow mode
         - PROBE_SENSORS (0x03): probe temperatures and humidity
-        - FULL_DATA_Q (0x06): triggers SCHEDULE (0x02) with remote temperature
+        - FULL_DATA_Q (0x06): triggers SCHEDULE (0x02) with remote temperature/humidity
 
         Separate requests are needed because some BLE proxies (e.g. ESPHome)
         only forward one notification per write command. FULL_DATA_Q returns
         multiple packets but the proxy may drop all but the first.
 
         Sensor data sources:
-        - Remote temperature: SCHEDULE packet byte 11
-        - Remote humidity: DEVICE_STATE packet byte 4
+        - Remote temperature/humidity: SCHEDULE packet bytes 11/13
         - Probe 1 temp/humidity: PROBE_SENSORS packet bytes 6/8
         - Probe 2 temperature: PROBE_SENSORS packet byte 11
 

--- a/src/visionair_ble/protocol.py
+++ b/src/visionair_ble/protocol.py
@@ -25,7 +25,7 @@ Packet types (phone → device):
   REQUEST; the phone uses SETTINGS only for a few specific configuration changes.
 
 Packet types (device → phone):
-- DEVICE_STATE (0x01): Device config, settings, and Remote humidity (182 bytes)
+- DEVICE_STATE (0x01): Device config and settings (182 bytes)
 - PROBE_SENSORS (0x03): Current probe temperature and humidity readings (182 bytes)
 - SCHEDULE (0x02): Time slot configuration + Remote temperature and humidity
 - SETTINGS_ACK (0x23): Acknowledgment of a SETTINGS write

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,69 @@
+import pytest
+
+from visionair_ble.client import VisionAirClient
+from visionair_ble.protocol import COMMAND_CHAR_UUID, STATUS_CHAR_UUID, MAGIC, PacketType
+
+
+class _Char:
+    def __init__(self, uuid: str):
+        self.uuid = uuid
+
+
+class _Service:
+    def __init__(self, characteristics):
+        self.characteristics = characteristics
+
+
+class _FakeBleClient:
+    def __init__(self, responses: list[bytes]):
+        self.services = [_Service([_Char(STATUS_CHAR_UUID), _Char(COMMAND_CHAR_UUID)])]
+        self.is_connected = True
+        self._responses = responses
+        self._handler = None
+
+    async def start_notify(self, _char, handler):
+        self._handler = handler
+
+    async def stop_notify(self, _char):
+        self._handler = None
+
+    async def write_gatt_char(self, _char, _data, response=True):
+        if self._handler and self._responses:
+            pkt = self._responses.pop(0)
+            self._handler(pkt)
+
+
+def _packet(packet_type: int) -> bytearray:
+    data = bytearray(182)
+    data[0:2] = MAGIC
+    data[2] = packet_type
+    return data
+
+
+@pytest.mark.asyncio
+async def test_get_fresh_status_prefers_schedule_remote_humidity() -> None:
+    """Regression test for issue #19.
+
+    get_fresh_status should populate remote humidity from SCHEDULE byte 13
+    rather than any stale DEVICE_STATE field.
+    """
+    schedule = _packet(PacketType.SCHEDULE)
+    schedule[11] = 21  # remote temp
+    schedule[13] = 52  # remote humidity
+
+    status = _packet(PacketType.DEVICE_STATE)
+    status[4] = 55  # legacy/stale candidate value; should NOT win
+    status[11] = 200  # configured volume bytes for parse_status
+
+    probes = _packet(PacketType.PROBE_SENSORS)
+    probes[6] = 18
+    probes[8] = 47
+    probes[11] = 11
+
+    fake = _FakeBleClient([bytes(schedule), bytes(status), bytes(probes)])
+    client = VisionAirClient(fake)
+
+    fresh = await client.get_fresh_status(timeout=0.2)
+
+    assert fresh.temp_remote == 21
+    assert fresh.humidity_remote == 52


### PR DESCRIPTION
Follow-up for #19 to remove stale/contradictory references to DEVICE_STATE byte 4 as remote humidity source.

Changes:
- update  docstring to state remote temp/humidity come from SCHEDULE (bytes 11/13)
- update protocol module overview to describe DEVICE_STATE as config/settings only
- update  note to remove old byte-4 wording

Validation:
- ........................................................................ [ 86%]
...........                                                              [100%]
83 passed in 0.08s (83 passed)