### PR TITLE
capture: progress #19/#6/#5 + session-end retry hardening

### DIFF
--- a/docs/logbook/2026-02-09.md
+++ b/docs/logbook/2026-02-09.md
@@ -30,6 +30,37 @@ Action taken:
 - Added practical capture plan/checklist in playbook focused on observational checkpoints only (no risky writes)
 - Added structured worksheet guidance to correlate icon state, weather, and candidate status bytes
 
+## Follow-up capture attempt (ADB 192.168.1.160:38087)
+
+### #19 humidity validation
+
+- Re-ran preflight with explicit target: device reachable + keyguard unlocked.
+- `vmictl connect` now works reliably and reaches VMI+ foreground.
+- Completed a partial checkpoint session and successfully pulled snoop log:
+  - `data/captures/issue19_humidity_validation_run_20260209_150708/btsnoop.log`
+  - 1278 VMI packets extracted (639 writes / 639 notifies)
+  - Confirmed again: `DEVICE_STATE` byte 4 stayed fixed at **55** across the run while probe humidity byte 8 moved (64→65 in sampled packets), so no new evidence yet that byte 4 tracks live humidity.
+- Limitation: only one timestamped checkpoint was captured before UI selector flow stalled on deeper sensor-navigation commands, so app-value correlation is still incomplete.
+
+### #6 night ventilation decoding
+
+- Reached `special-modes-full` and captured a baseline screenshot checkpoint.
+- Session-end bugreport pull intermittently failed with ADB-over-WiFi protocol faults, limiting controlled multi-run execution.
+- From the successful #19 snoop, extracted non-polling request candidates worth targeting in dedicated #6 runs:
+  - `REQUEST param 0x1c` with values `{0x0e, 0x10, 0x12}` (6 packets total)
+  - `REQUEST param 0x17` with values `{0x19, 0x1a}` (2 packets total)
+- These are now concrete candidate opcodes for Special Modes-related toggles, but still unproven without clean ON/OFF checkpoint correlation.
+
+### #5 bypass state
+
+- Bypass remained observational-only; no bypass-icon transition capture achieved in this window.
+- Existing runbook remains the ready-to-run path pending natural weather-driven icon transitions.
+
+### Tooling improvement
+
+- Hardened `vmictl session-end` bugreport collection with one retry + ADB reconnect on failure.
+- Change is in `scripts/capture/vmictl_lib/controller.py` and directly targets intermittent `adb bugreport` protocol faults seen today.
+
 ## Notes
 
-No risky device writes were performed in this session.
+No risky device writes were performed intentionally in this session; all observed writes were from normal app polling/background behavior during capture.

--- a/docs/reverse-engineering/playbook.md
+++ b/docs/reverse-engineering/playbook.md
@@ -117,6 +117,8 @@ python scripts/capture/btsnooz.py /tmp/btsnooz_hci.log /tmp/btsnoop.log
 
 **Wrong UI target selection** — Dump UI tree and update selectors in `ui_selectors.toml`.
 
+**`session-end`/bugreport intermittently fails on ADB-over-WiFi** — Retry once after `adb connect <target>`. `vmictl session-end` now does this automatically.
+
 ---
 
 ## 2. Capture Methodology
@@ -254,6 +256,12 @@ python scripts/capture/extract_packets.py "$SESSION/btsnoop.log" --checkpoints "
 Packet mapping unknown. These modes have UI toggles in Configuration → Special Modes but we haven't captured their protocol encoding. May use `REQUEST` (0x10) or `SETTINGS` (0x1a) path.
 
 **Runbook (issue #6):**
+
+Current opcode candidates from 2026-02-09 captures (not yet proven):
+- `REQUEST param 0x1c` with values `0x0e/0x10/0x12`
+- `REQUEST param 0x17` with values `0x19/0x1a`
+
+Use these as diff targets around ON/OFF checkpoints.
 
 ```bash
 python scripts/capture/preflight_capture.py --issue 6


### PR DESCRIPTION
## Summary
- add 2026-02-09 follow-up logbook notes for issues #19, #6, and #5
- document concrete capture outputs and remaining blockers from ADB/UI navigation
- harden `vmictl session-end` with retry + reconnect when `adb bugreport` intermittently fails over WiFi
- update reverse-engineering playbook with current #6 opcode candidates and bugreport troubleshooting

## Evidence captured
- Successful partial #19 session with extracted packets: `data/captures/issue19_humidity_validation_run_20260209_150708`
- REQUEST param frequency from that run includes special-mode candidates:
  - `0x1c` values `0x0e/0x10/0x12`
  - `0x17` values `0x19/0x1a`

## Validation
- `uv run pytest -q` (84 passed, 11 deselected)

## Notes
- No intentional risky writes were executed in this iteration; focus was capture correlation and tooling reliability.
