### PR TITLE
investigate: SETTINGS bytes are clock sync, not airflow (#21)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -47,7 +47,7 @@ This document tracks which protocol features from [protocol.md](protocol.md) are
 | `ScheduleSlot` dataclass | Yes | Yes | Per-hour schedule slot (preheat temp + mode) |
 | `ScheduleConfig` dataclass | Yes | Yes | 24-hour schedule (list of slots) |
 | Schedule mode byte mapping | Yes | Yes | LOW=0x28, MEDIUM=0x32, HIGH=0x3C |
-| Airflow mode mapping | Yes | Yes | LOW/MEDIUM/HIGH — "airflow bytes" are clock sync artifacts (see #21) |
+| Airflow mode mapping | Yes | Yes | LOW/MEDIUM/HIGH — `AIRFLOW_BYTES` values are unverified (see #21) |
 | Volume-based calculation | Yes | Yes | ACH multipliers |
 | Sensor metadata for HA | Yes | Yes | Auto-discovery support |
 
@@ -66,4 +66,4 @@ Features that need more data before implementing:
 
 - **Diagnostic bitfield (byte 54)** — Only value 0x0F (all healthy) observed. Bit-to-component mapping is assumed based on UI order. Need a device with a faulty component to verify.
 
-- **~~Airflow setting bytes~~** — Resolved (#21). The byte pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) are clock sync minute:second values from early captures, not airflow configuration. SETTINGS bytes 7-10 carry (day, hour, minute, second). See protocol.md §7.1.
+- **~~Airflow setting bytes~~** — SETTINGS bytes 7-10 carry clock sync (day, hour, minute, second). The byte pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) are plausible timestamp values and are not confirmed as airflow configuration. See protocol.md §7.1 and #21.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -12,7 +12,7 @@ This document tracks which protocol features from [protocol.md](protocol.md) are
 | Mode Select (0x10, param 0x18) | Yes | Yes | `build_mode_select_request(mode)` — controls fan speed. Physical speed change verified via vibration sensor 2026-02-08 ([#22](https://github.com/bartcortooms/visionair-ble/issues/22)) |
 | BOOST ON/OFF (0x10, param 0x19) | Yes | Yes | `build_boost_command()` |
 | Preheat Toggle (0x10, param 0x2F) | Yes | Yes | `build_preheat_request()` |
-| Settings (0x1a) - airflow/summer/temp | Yes | Yes | `build_settings_packet()` |
+| Settings (0x1a) - clock sync | Yes | No | Phone sends clock sync only; library sends config-mode packet (unverified, see #21) |
 | Holiday Command (0x10, param 0x1a) | Yes | Yes | `build_holiday_command(days)`, `VisionAirClient.set_holiday()` / `clear_holiday()` |
 | Unknown Query (0x10, param 0x2c) | Yes | Yes | `build_unknown_2c_query()` |
 | Night Ventilation (0x1a, byte7=0x04) — hypothetical | Partial | Experimental | `build_night_ventilation_activate()` — [#6](https://github.com/bartcortooms/visionair-ble/issues/6) |
@@ -47,7 +47,7 @@ This document tracks which protocol features from [protocol.md](protocol.md) are
 | `ScheduleSlot` dataclass | Yes | Yes | Per-hour schedule slot (preheat temp + mode) |
 | `ScheduleConfig` dataclass | Yes | Yes | 24-hour schedule (list of slots) |
 | Schedule mode byte mapping | Yes | Yes | LOW=0x28, MEDIUM=0x32, HIGH=0x3C |
-| Airflow mode mapping | Yes | Yes | LOW/MEDIUM/HIGH — byte meaning unknown |
+| Airflow mode mapping | Yes | Yes | LOW/MEDIUM/HIGH — "airflow bytes" are clock sync artifacts (see #21) |
 | Volume-based calculation | Yes | Yes | ACH multipliers |
 | Sensor metadata for HA | Yes | Yes | Auto-discovery support |
 
@@ -66,4 +66,4 @@ Features that need more data before implementing:
 
 - **Diagnostic bitfield (byte 54)** — Only value 0x0F (all healthy) observed. Bit-to-component mapping is assumed based on UI order. Need a device with a faulty component to verify.
 
-- **Airflow setting bytes** — The byte pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) work for LOW/MEDIUM/HIGH but their actual meaning (PWM? calibration?) is unknown.
+- **~~Airflow setting bytes~~** — Resolved (#21). The byte pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) are clock sync minute:second values from early captures, not airflow configuration. SETTINGS bytes 7-10 carry (day, hour, minute, second). See protocol.md §7.1.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -66,4 +66,4 @@ Features that need more data before implementing:
 
 - **Diagnostic bitfield (byte 54)** — Only value 0x0F (all healthy) observed. Bit-to-component mapping is assumed based on UI order. Need a device with a faulty component to verify.
 
-- **~~Airflow setting bytes~~** — SETTINGS bytes 7-10 carry clock sync (day, hour, minute, second). The byte pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) are plausible timestamp values and are not confirmed as airflow configuration. See protocol.md §7.1 and #21.
+- **~~SETTINGS byte-pair semantics~~** — SETTINGS bytes 7-10 carry clock sync (day, hour, minute, second). The `AIRFLOW_BYTES` pairs (0x19/0x0A, 0x28/0x15, 0x07/0x30) are plausible timestamp values; their role as airflow configuration is unverified. See protocol.md §7.1 and #21.

--- a/docs/logbook/2026-02-09.md
+++ b/docs/logbook/2026-02-09.md
@@ -61,6 +61,70 @@ Action taken:
 - Hardened `vmictl session-end` bugreport collection with one retry + ADB reconnect on failure.
 - Change is in `scripts/capture/vmictl_lib/controller.py` and directly targets intermittent `adb bugreport` protocol faults seen today.
 
+## #21 SETTINGS airflow bytes investigation
+
+### Question
+
+What do SETTINGS bytes 9-10 ("airflow bytes") and byte 7 actually encode?
+The library has `AIRFLOW_BYTES` with three byte pairs extracted from early
+captures: LOW=(0x19, 0x0A), MEDIUM=(0x28, 0x15), HIGH=(0x07, 0x30).
+
+### Method
+
+Analyzed all SETTINGS packets from two independent controlled captures:
+- `fan_speed_capture_20260207_171617`: 5 SETTINGS packets
+- `issue19_humidity_validation_run_20260209_150708`: 13 SETTINGS packets
+
+Decoded bytes 7-10 under both the old config interpretation (summer limit,
+preheat temp, airflow bytes) and the clock sync interpretation (day, hour,
+minute, second).
+
+### Findings
+
+**Bytes 9-10 are minute:second (clock sync).** All 18 SETTINGS packets across
+both captures decode as valid timestamps with monotonically increasing hours
+and sensible minute/second values. The day values (byte 7) match the capture
+dates: 0x07 = Feb 7, 0x08 = Feb 8, 0x09 = Feb 9.
+
+**Byte 7 is day-of-month, not a mode selector.** Values 0x06-0x09 observed.
+
+**Byte 8 is the hour, not preheat temperature.** Several captured packets have
+byte 8 = 0x09 (hour 9) which is outside the valid preheat range (12-18°C),
+disproving the preheat temperature interpretation.
+
+**The "airflow bytes" were clock sync artifacts.** The pairs from early
+captures (0x19/0x0A = min 25/sec 10, etc.) are plausible minute:second values.
+No controlled capture contains SETTINGS packets with these specific byte pairs.
+
+**No SETTINGS packet with byte 7 = 0x00 or 0x02 has been observed in any
+controlled capture.** The early-capture values that motivated `SettingsMode.NORMAL`
+and `SettingsMode.SUMMER_LIMIT` may have been low day-of-month values.
+
+### Impact on codebase
+
+- `AIRFLOW_BYTES` constant: contains clock sync artifacts, not airflow config
+- `SettingsMode.NORMAL` / `SUMMER_LIMIT`: unverified mode codes
+- `build_settings_packet()`: sends bytes the phone never sends
+- `set_summer_limit()`: uses build_settings_packet() and reportedly works,
+  but exact mechanism is unclear
+
+### Changes made
+
+- Added investigation comments to `AIRFLOW_BYTES`, `SettingsMode`, and
+  `build_settings_packet()` in protocol.py
+- Updated protocol.md §7.1 with full evidence tables from both captures
+- Updated protocol.md open questions (marked SETTINGS bytes as resolved)
+- Updated implementation-status.md
+- Added `TestSettingsClockSync` test class with 12 captured packet vectors
+- No behavioral changes — symbols and function signatures unchanged
+
+### Open
+
+- Whether the device firmware supports config-mode SETTINGS (byte 7 <= 0x05)
+  alongside clock sync (byte 7 >= 0x06) is unverified
+- A capture of the phone's summer limit toggle would clarify how the phone
+  actually changes summer limit settings (SETTINGS vs some other mechanism)
+
 ## Notes
 
 No risky device writes were performed intentionally in this session; all observed writes were from normal app polling/background behavior during capture.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -369,7 +369,8 @@ Each slot is 2 bytes:
 | Mode 3 | 0x3C | 60 | HIGH |
 
 > **Note:** The decimal values follow a regular 40/50/60 pattern, unlike the
-> settings airflow bytes which use unrelated two-byte pairs.
+> `AIRFLOW_BYTES` pairs used by `build_settings_packet()` (two-byte pairs
+> with unverified semantics).
 
 **Example** (hour 0 set to HIGH at 18°C, hours 1-8 LOW, 9-17 MEDIUM, 18-23 LOW):
 ```

--- a/src/visionair_ble/protocol.py
+++ b/src/visionair_ble/protocol.py
@@ -301,7 +301,7 @@ DEVICE_NAMES = ("visionair", "purevent", "urban", "cube")
 # Airflow Configuration
 # =============================================================================
 
-# Airflow mode -> (byte1, byte2) for settings packet bytes 9-10.
+# SETTINGS packet bytes 9-10 — byte pairs keyed by airflow level.
 #
 # Used by build_settings_packet() for config-mode SETTINGS writes.
 # These byte pairs are also valid as clock sync minute:second values,
@@ -322,7 +322,7 @@ AIRFLOW_INDICATOR: dict[int, int] = {
 }
 
 # Schedule slot mode byte <-> AirflowLevel
-# These differ from settings airflow bytes (which use two-byte pairs).
+# These differ from AIRFLOW_BYTES (which use two-byte pairs for SETTINGS).
 # Schedule slots use a single byte per mode.
 SCHEDULE_MODE_BYTES: dict[int, int] = {
     AirflowLevel.LOW: 0x28,
@@ -341,7 +341,7 @@ MODE_NAMES: dict[int, str] = {
 
 
 class AirflowBytes(NamedTuple):
-    """Airflow encoding as two bytes."""
+    """Two-byte pair for SETTINGS packets (semantics unverified)."""
 
     byte1: int
     byte2: int
@@ -861,13 +861,13 @@ def build_settings_packet(
     """Build a settings command packet (type 0x1a).
 
     Constructs a config-mode SETTINGS packet with summer limit, preheat
-    temperature, and airflow bytes. Preheat on/off is toggled separately
-    via build_preheat_request().
+    temperature, and `AIRFLOW_BYTES` pair. Preheat on/off is toggled
+    separately via build_preheat_request().
 
     Note: The phone app uses SETTINGS for clock sync (bytes 7-10 = day,
     hour, minute, second), not config writes. This config-mode format
-    (byte 7 = summer limit mode, bytes 9-10 = airflow bytes) is used
-    by set_summer_limit() and the device responds with SETTINGS_ACK,
+    (byte 7 = summer limit mode, bytes 9-10 = `AIRFLOW_BYTES` pair) is
+    used by set_summer_limit() and the device responds with SETTINGS_ACK,
     but the exact byte semantics are unverified against the phone app.
 
     Args:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -128,7 +128,7 @@ class TestPacketBuilding:
             preheat_temp=16,
             airflow=AIRFLOW_MEDIUM,
         )
-        # Verify structure: magic + type + header + flags + temp + airflow bytes + checksum
+        # Verify structure: magic + type + header + flags + temp + AIRFLOW_BYTES pair + checksum
         assert packet[:2] == b"\xa5\xb6"  # magic
         assert packet[2] == 0x1a  # type
         assert packet[6] == 0x02  # byte 6 is always 0x02


### PR DESCRIPTION
## Summary
- Investigated issue #21 with controlled Feb 7/Feb 9 capture analysis
- Concluded SETTINGS bytes 7-10 are clock sync fields (day/hour/minute/second), not airflow mode selectors
- Updated protocol docs/comments to reflect findings and remaining uncertainty around config-write semantics
- Added tests to lock in decoded behavior from captured packets
- Updated implementation status + logbook with investigation notes

## Validation
- Added `TestSettingsClockSync` class in `tests/test_protocol.py` with 12 captured packet vectors and 9 test methods
- `uv run pytest -v` — 93 passed, 11 deselected (E2E) in 0.28s

Closes #21