### PR TITLE
cleanup: align remaining artifacts with SETTINGS clock-sync findings

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -47,7 +47,7 @@ This document tracks which protocol features from [protocol.md](protocol.md) are
 | `ScheduleSlot` dataclass | Yes | Yes | Per-hour schedule slot (preheat temp + mode) |
 | `ScheduleConfig` dataclass | Yes | Yes | 24-hour schedule (list of slots) |
 | Schedule mode byte mapping | Yes | Yes | LOW=0x28, MEDIUM=0x32, HIGH=0x3C |
-| Airflow mode mapping | Yes | Yes | LOW/MEDIUM/HIGH — `AIRFLOW_BYTES` values are unverified (see #21) |
+| `AIRFLOW_BYTES` | Partial | Yes | Config-mode byte pairs keyed by airflow level; unverified — may be clock sync artifacts (see #21) |
 | Volume-based calculation | Yes | Yes | ACH multipliers |
 | Sensor metadata for HA | Yes | Yes | Auto-discovery support |
 

--- a/docs/reverse-engineering/playbook.md
+++ b/docs/reverse-engineering/playbook.md
@@ -325,7 +325,7 @@ For reference — these are fully decoded and implemented.
 | Holiday mode | REQUEST param 0x1a, byte 9 = days | Implemented |
 | Equipment life | DEVICE_STATE bytes 26-29 | Implemented |
 | Summer limit threshold | DEVICE_STATE byte 38 | Implemented |
-| Airflow settings | SETTINGS 0x1a, bytes 9-10 | Implemented |
+| Clock sync | SETTINGS 0x1a, bytes 7-10 | Observed (config-mode unverified) |
 | Preheat control | SETTINGS 0x1a, bytes 6+8 | Implemented |
 | Schedule config | 0x40 write / 0x46 response | Experimental |
 

--- a/src/visionair_ble/protocol.py
+++ b/src/visionair_ble/protocol.py
@@ -651,9 +651,7 @@ def build_boost_command(enable: bool) -> bytes:
 def build_preheat_request(enable: bool) -> bytes:
     """Build a preheat toggle command packet.
 
-    Toggles preheat mode on or off. This is a separate command from the
-    SETTINGS packet — the SETTINGS packet controls airflow/temperature,
-    while this REQUEST controls the preheat on/off state.
+    Toggles preheat mode on or off via REQUEST param 0x2F.
 
     Args:
         enable: True to enable preheat, False to disable


### PR DESCRIPTION
## Summary

Follow-up to #34 — cleans remaining naming/docs/script artifacts from the SETTINGS clock-sync investigation:

- **`scripts/analyze_settings_packets.py`**: Removed old airflow byte-pair decode (LOW/MEDIUM/HIGH labels and `airflow_names` dict). Now decodes bytes 7-10 as clock sync fields (day, hour, minute, second) and flags low byte-7 values as potential config-mode.
- **`src/visionair_ble/protocol.py`**: Removed misleading `build_preheat_request()` comment that said "the SETTINGS packet controls airflow/temperature".
- **`docs/reverse-engineering/playbook.md`**: Changed "Airflow settings" completed-investigation entry to "Clock sync" with config-mode-unverified status.
- **`docs/implementation-status.md`**: Reworded `AIRFLOW_BYTES` row to clarify these are config-mode byte pairs that may be clock sync artifacts.

Historical logbook entries are preserved as-is (out of scope).

## Test plan

- [x] `uv run pytest tests/test_protocol.py -v` — 92 passed in 0.27s
